### PR TITLE
Fix CLI manifest path resolution for system installs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -159,9 +159,36 @@ llm-guard-xxx                     1/1     Running   0          1m
 
 ## Step 7: Install the CLI
 
+The CLI needs access to manifest templates. Choose one option:
+
+### Option A: System Install (Recommended)
+
 ```bash
+# Install CLI
 sudo cp scripts/yolo-cage /usr/local/bin/
 sudo chmod +x /usr/local/bin/yolo-cage
+
+# Install manifests
+sudo mkdir -p /usr/local/share/yolo-cage
+sudo cp -r manifests /usr/local/share/yolo-cage/
+```
+
+### Option B: Environment Variable
+
+If you prefer to keep everything in your cloned repo:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export YOLO_CAGE_HOME="$HOME/yolo-cage"
+export PATH="$YOLO_CAGE_HOME/scripts:$PATH"
+```
+
+### Option C: Run from Repo
+
+Simply run the CLI from your cloned directory:
+
+```bash
+~/yolo-cage/scripts/yolo-cage create feature-auth
 ```
 
 ## Step 8: Create Your First Sandbox

--- a/scripts/yolo-cage
+++ b/scripts/yolo-cage
@@ -19,9 +19,33 @@ set -e
 DEFAULT_NAMESPACE="yolo-cage"
 NAMESPACE="${DEFAULT_NAMESPACE}"
 
-# Configuration
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MANIFESTS_DIR="${SCRIPT_DIR}/../manifests"
+# Find manifests directory
+# Priority: YOLO_CAGE_HOME > relative to script > system install location
+find_manifests_dir() {
+    # 1. Environment variable (explicit override)
+    if [[ -n "${YOLO_CAGE_HOME:-}" && -d "${YOLO_CAGE_HOME}/manifests" ]]; then
+        echo "${YOLO_CAGE_HOME}/manifests"
+        return
+    fi
+
+    # 2. Relative to script (dev/cloned repo)
+    local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -d "${script_dir}/../manifests" ]]; then
+        echo "${script_dir}/../manifests"
+        return
+    fi
+
+    # 3. System install location
+    if [[ -d "/usr/local/share/yolo-cage/manifests" ]]; then
+        echo "/usr/local/share/yolo-cage/manifests"
+        return
+    fi
+
+    # Not found
+    echo ""
+}
+
+MANIFESTS_DIR="$(find_manifests_dir)"
 
 # Parse global options
 while [[ $# -gt 0 ]]; do
@@ -119,6 +143,21 @@ cmd_create() {
     echo "Pod name: ${pod}"
 
     # Generate pod manifest from template
+    if [[ -z "$MANIFESTS_DIR" ]]; then
+        echo "Error: Could not find yolo-cage manifests directory."
+        echo ""
+        echo "Searched in:"
+        echo "  - \$YOLO_CAGE_HOME/manifests (env var not set)"
+        echo "  - $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../manifests (not found)"
+        echo "  - /usr/local/share/yolo-cage/manifests (not found)"
+        echo ""
+        echo "Either:"
+        echo "  - Run from the cloned yolo-cage repo, or"
+        echo "  - Set YOLO_CAGE_HOME to your yolo-cage directory, or"
+        echo "  - Install manifests: sudo cp -r manifests /usr/local/share/yolo-cage/"
+        exit 1
+    fi
+
     local template="${MANIFESTS_DIR}/sandbox/pod-template.yaml"
     if [[ ! -f "$template" ]]; then
         echo "Error: Pod template not found at ${template}"


### PR DESCRIPTION
## Summary
- CLI now searches for manifests in multiple locations instead of assuming it's running from the cloned repo
- Search order: `$YOLO_CAGE_HOME/manifests` → relative to script → `/usr/local/share/yolo-cage/manifests`
- Helpful error message when manifests not found
- Updated setup docs with three install options (system install, env var, run from repo)

## Test plan
- [ ] Install CLI to /usr/local/bin without manifests → should show helpful error
- [ ] Install CLI + manifests to /usr/local/share/yolo-cage → should work
- [ ] Run from cloned repo → should work (existing behavior)
- [ ] Set YOLO_CAGE_HOME and run → should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)