### PR TITLE
Fix .claude directory permissions and CLI output

### DIFF
--- a/manifests/base/sandbox/pod-template.yaml
+++ b/manifests/base/sandbox/pod-template.yaml
@@ -33,6 +33,23 @@ spec:
         - name: ca-bundle
           mountPath: /ca-bundle
 
+    # Set up .claude directory with correct permissions
+    # (secret subPath mounts create parent dirs as root, breaking writes)
+    - name: setup-claude-home
+      image: python:3.12-slim-bookworm
+      command:
+        - /bin/sh
+        - -c
+        - |
+          cp /secrets/claude-oauth-credentials /claude-home/credentials.json
+          chmod 600 /claude-home/credentials.json
+      volumeMounts:
+        - name: claude-credentials
+          mountPath: /secrets
+          readOnly: true
+        - name: claude-home
+          mountPath: /claude-home
+
   containers:
     - name: yolo-cage
       image: localhost:32000/yolo-cage:latest
@@ -84,10 +101,8 @@ spec:
       volumeMounts:
         - name: workspaces
           mountPath: /workspaces
-        - name: claude-credentials
-          mountPath: /home/dev/.claude/credentials.json
-          subPath: claude-oauth-credentials
-          readOnly: true
+        - name: claude-home
+          mountPath: /home/dev/.claude
         - name: proxy-ca
           mountPath: /etc/ssl/certs/mitmproxy-ca.pem
           subPath: mitmproxy-ca.pem
@@ -111,6 +126,9 @@ spec:
           - key: claude-oauth-credentials
             path: claude-oauth-credentials
             mode: 0600
+
+    - name: claude-home
+      emptyDir: {}
 
     - name: proxy-ca
       configMap:

--- a/scripts/yolo-cage
+++ b/scripts/yolo-cage
@@ -68,20 +68,14 @@ usage() {
 yolo-cage - Sandboxed Claude Code agents with git isolation
 
 Usage:
-  yolo-cage create <branch> [-n namespace]   Create pod for branch
-  yolo-cage list [-n namespace]              List active pods
-  yolo-cage attach <branch> [-n namespace]   Exec into pod
-  yolo-cage delete <branch> [-n namespace]   Remove pod
-  yolo-cage logs <branch> [-n namespace]     Tail pod logs
+  yolo-cage [-n namespace] create <branch>   Create pod for branch
+  yolo-cage [-n namespace] list              List active pods
+  yolo-cage [-n namespace] attach <branch>   Exec into pod
+  yolo-cage [-n namespace] delete <branch>   Remove pod
+  yolo-cage [-n namespace] logs <branch>     Tail pod logs
 
 Options:
   -n, --namespace NAME    Kubernetes namespace (default: ${DEFAULT_NAMESPACE})
-
-Examples:
-  yolo-cage create feature-auth
-  yolo-cage attach feature-auth
-  yolo-cage list
-  yolo-cage delete feature-auth -n myproject
 EOF
     exit 1
 }
@@ -189,7 +183,11 @@ cmd_create() {
     echo "Pod ${pod} is ready."
     echo ""
     echo "Launch Claude with:"
-    echo "  yolo-cage attach ${branch}"
+    if [[ "$NAMESPACE" != "$DEFAULT_NAMESPACE" ]]; then
+        echo "  yolo-cage -n ${NAMESPACE} attach ${branch}"
+    else
+        echo "  yolo-cage attach ${branch}"
+    fi
 }
 
 cmd_list() {


### PR DESCRIPTION
## Summary

**Pod template:**
- Add init container to set up `.claude` dir with correct ownership
- Secret subPath mounts create parent dirs as root, which broke Claude's ability to write to `~/.claude/todos` etc.
- Use emptyDir for `.claude` and copy credentials in init container

**CLI:**
- Include `-n namespace` in attach output when using non-default namespace
- Fix usage to show `-n` flag position correctly (before command, not after)
- Remove redundant examples section (usage is clear enough)

## Test plan
- [ ] Create pod, verify `.claude` is owned by dev user
- [ ] `yolo-cage attach` works and Claude can write to `.claude/`
- [ ] Non-default namespace shows correct attach command

🤖 Generated with [Claude Code](https://claude.com/claude-code)