### PR TITLE
Reduce pod termination grace period to 5 seconds

### DIFF
--- a/manifests/base/sandbox/pod-template.yaml
+++ b/manifests/base/sandbox/pod-template.yaml
@@ -10,6 +10,7 @@ metadata:
     yolo-cage/branch: ${BRANCH}
 spec:
   restartPolicy: Never
+  terminationGracePeriodSeconds: 5
 
   securityContext:
     runAsUser: 1000


### PR DESCRIPTION
## Summary

`kubectl delete pod` was taking ~100 seconds because:
- Pod uses `sleep infinity` which ignores SIGTERM
- Kubernetes waits the full grace period (default 30s) before SIGKILL
- With additional cleanup overhead, this felt very slow

Set `terminationGracePeriodSeconds: 5` since there's no stateful process that needs graceful shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)