### PR TITLE
Exclude proxy-ca from kustomize to prevent overwriting

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -89,7 +89,11 @@ rm claude-credentials.json
 
 ## Step 4: Generate Proxy CA Certificate
 
-The egress proxy needs a CA certificate for HTTPS interception:
+The egress proxy needs a CA certificate for HTTPS interception.
+
+> **Important**: This ConfigMap is intentionally excluded from kustomize because
+> it's environment-specific. You must create it manually before Step 6, and
+> re-running `kubectl apply -k` will not overwrite it.
 
 ```bash
 # Generate CA key and certificate

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -15,8 +15,9 @@ resources:
   # Proxy
   - proxy/egress-proxy.yaml
   - proxy/llm-guard.yaml
-  - proxy/proxy-ca.yaml
   - proxy/configmap.yaml
+  # Note: proxy-ca.yaml is NOT included - it must be created manually
+  # before deploying (see docs/setup.md Step 4)
   # Sandbox infrastructure
   - sandbox/networkpolicy.yaml
   - sandbox/pvc.yaml

--- a/manifests/base/proxy/proxy-ca.yaml
+++ b/manifests/base/proxy/proxy-ca.yaml
@@ -1,20 +1,15 @@
 # Proxy CA certificate for HTTPS interception
 #
-# IMPORTANT: This is a placeholder. After deploying the egress-proxy,
-# you need to extract the actual CA certificate and update this ConfigMap.
+# NOTE: This file is NOT applied by kustomize. It exists as a reference only.
+# You must create the proxy-ca ConfigMap manually before deploying.
+# See docs/setup.md Step 4 for instructions.
 #
-# Steps:
-# 1. Deploy egress-proxy first (it will generate a CA on startup)
-# 2. Extract the CA:
-#    kubectl exec -n <namespace> deployment/egress-proxy -- \
-#      cat /home/mitmproxy/.mitmproxy/mitmproxy-ca-cert.pem > mitmproxy-ca.pem
-# 3. Update this ConfigMap:
-#    kubectl create configmap proxy-ca \
-#      --namespace=<namespace> \
-#      --from-file=mitmproxy-ca.pem=mitmproxy-ca.pem \
-#      --dry-run=client -o yaml | kubectl apply -f -
-# 4. Restart yolo-cage to pick up the new CA:
-#    kubectl rollout restart -n <namespace> deployment/yolo-cage
+# Alternative: Extract the CA from a running egress-proxy:
+#   kubectl exec -n <namespace> deployment/egress-proxy -- \
+#     cat /home/mitmproxy/.mitmproxy/mitmproxy-ca-cert.pem > mitmproxy-ca.pem
+#   kubectl create configmap proxy-ca \
+#     --namespace=<namespace> \
+#     --from-file=mitmproxy-ca.pem=mitmproxy-ca.pem
 #
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Summary
- Remove proxy-ca.yaml from kustomization.yaml resources so `kubectl apply -k` doesn't overwrite the manually-created ConfigMap with a placeholder
- Update setup.md with a note explaining why this is excluded
- Update proxy-ca.yaml header to clarify it's a reference only

## Problem
When following setup.md, Step 4 creates the proxy-ca ConfigMap manually. But Step 6 (`kubectl apply -k`) overwrites it with the placeholder from the manifest, breaking TLS connections.

## Test plan
- [ ] Follow setup.md steps 1-6
- [ ] Verify proxy-ca ConfigMap contains real certificate after Step 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)