### PR TITLE
Fix workspace isolation: mount only agent's branch

### DIFF
--- a/manifests/sandbox/pod-template.yaml
+++ b/manifests/sandbox/pod-template.yaml
@@ -34,30 +34,21 @@ spec:
         - name: ca-bundle
           mountPath: /ca-bundle
 
-    # Set up .claude directory with correct permissions
-    # Uses persistent storage so auth tokens survive pod restarts
+    # Set up .claude directory with credentials from secret
     - name: setup-claude-home
       image: python:3.12-slim-bookworm
       command:
         - /bin/sh
         - -c
         - |
-          # Create branch-specific .claude directory under .claude-homes/
-          mkdir -p /workspaces/.claude-homes/${BRANCH}
-          # Copy credentials if not already present (preserve existing auth state)
-          if [ ! -f /workspaces/.claude-homes/${BRANCH}/credentials.json ]; then
-            cp /secrets/claude-oauth-credentials /workspaces/.claude-homes/${BRANCH}/credentials.json
-            chmod 600 /workspaces/.claude-homes/${BRANCH}/credentials.json
-          fi
-      env:
-        - name: BRANCH
-          value: "${BRANCH}"
+          cp /secrets/claude-oauth-credentials /claude-home/credentials.json
+          chmod 600 /claude-home/credentials.json
       volumeMounts:
         - name: claude-credentials
           mountPath: /secrets
           readOnly: true
-        - name: workspaces
-          mountPath: /workspaces
+        - name: claude-home
+          mountPath: /claude-home
 
   containers:
     - name: yolo-cage
@@ -109,10 +100,10 @@ spec:
 
       volumeMounts:
         - name: workspaces
-          mountPath: /workspaces
-        - name: workspaces
+          mountPath: /workspace
+          subPath: ${BRANCH}
+        - name: claude-home
           mountPath: /home/dev/.claude
-          subPath: .claude-homes/${BRANCH}
         - name: proxy-ca
           mountPath: /etc/ssl/certs/mitmproxy-ca.pem
           subPath: mitmproxy-ca.pem
@@ -139,6 +130,9 @@ spec:
           - key: claude-oauth-credentials
             path: claude-oauth-credentials
             mode: 0600
+
+    - name: claude-home
+      emptyDir: {}
 
     - name: proxy-ca
       configMap:

--- a/scripts/yolo-cage
+++ b/scripts/yolo-cage
@@ -233,7 +233,7 @@ cmd_attach() {
     echo ""
     kubectl exec -it -n "${NAMESPACE}" "${pod}" -- \
         /bin/bash -c '
-            cd /workspaces/'"${branch}"'
+            cd /workspace
 
             # Read first-turn prompt if available (only used on new session)
             FIRST_TURN=""

--- a/scripts/yolo-cage-init
+++ b/scripts/yolo-cage-init
@@ -11,7 +11,7 @@ set -e
 
 BRANCH="${YOLO_CAGE_BRANCH:-}"
 DISPATCHER="${YOLO_CAGE_DISPATCHER:-http://git-dispatcher:8080}"
-WORKSPACE="/workspaces/${BRANCH}"
+WORKSPACE="/workspace"
 
 if [[ -z "$BRANCH" ]]; then
     echo "Error: YOLO_CAGE_BRANCH not set"


### PR DESCRIPTION
## Summary

- Mount agent's workspace at `/workspace` with `subPath: ${BRANCH}` instead of full `/workspaces`
- Agent cannot access other agents' worktrees or `.claude` directories
- Credentials use simple emptyDir (same shared credentials for all agents)
- Dispatcher retains full access to all workspaces

## Security fix

Previously agents could see all workspaces:
```bash
ls /workspaces/  # Could see all branches
```

Now agents only see their own:
```bash
ls /workspace/   # Only their branch
ls /workspaces/  # No such file or directory
```

## Test plan

- [ ] Create pod, verify `/workspace` contains only the agent's branch
- [ ] Verify `ls /workspaces` fails (no such directory)
- [ ] Verify agent can still do git operations
- [ ] Verify `gh issue list` works

🤖 Generated with [Claude Code](https://claude.ai/code)